### PR TITLE
Fall back to Home class when cloud login omits curHome

### DIFF
--- a/custom_components/pixie_plus_local/pixie_runtime.py
+++ b/custom_components/pixie_plus_local/pixie_runtime.py
@@ -1916,6 +1916,43 @@ class PixieAuthHandler:
                 meshnet,
             )
 
+            # Fallback: many Pixie accounts do not include `curHome` in the login
+            # response, leaving homeid/meshNet/netID unresolved ("unknown"). In that
+            # case, query the Home class directly and adopt the account's home.
+            if homeid is None or str(homeid) in ("", "unknown", "None"):
+                try:
+                    home_list_headers = {
+                        "x-parse-session-token": sessiontoken,
+                        "x-parse-application-id": APPLICATION_ID,
+                        "x-parse-client-key": CLIENT_KEY,
+                    }
+                    home_list_resp = httpx.get(
+                        API_URL["home"], params={"limit": 10}, headers=home_list_headers
+                    )
+                    home_list_resp.raise_for_status()
+                    home_results = home_list_resp.json().get("results", [])
+                    if home_results:
+                        home0 = home_results[0]
+                        homeid = home0.get("objectId", homeid)
+                        if home0.get("name"):
+                            home_name = str(home0.get("name"))
+                        if home0.get("meshNet") is not None:
+                            meshnet = str(home0.get("meshNet"))
+                        if home0.get("meshNet2") is not None:
+                            meshnet2 = str(home0.get("meshNet2"))
+                        if home0.get("netID") is not None:
+                            netid = str(home0.get("netID"))
+                        self._log_debug(
+                            "Resolved home via Home-class fallback: home=%s meshNet=%s meshNet2=%s netID=%s",
+                            homeid, meshnet, meshnet2, netid,
+                        )
+                    else:
+                        self._log_warning(
+                            "Home-class fallback returned no homes for this account"
+                        )
+                except Exception as exc:
+                    self._log_debug("Home-class fallback failed: %s", exc)
+
             # Try to get meshNet from LiveGroup
             try:
                 headers = {


### PR DESCRIPTION
## Summary

Fixes setup failing with **"Could not connect to the Pixie gateway"** for accounts whose cloud **login response does not include `curHome`**.

On such accounts, `_fetch_login_data()` leaves `homeid`/`meshNet`/`netID` as `"unknown"`, so `config_flow._async_validate_setup_input()` aborts at:

```python
raise CannotConnect("Cloud login did not return usable mesh metadata")
```

…before the integration ever contacts the gateway. The generic "Could not connect to the Pixie gateway" message makes this look like a network problem, but the gateway is fully reachable (UDP 41580 / TCP 41578) — the run simply never gets that far.

## Root cause

`_fetch_login_data()` only derives the home from the login payload:

```python
home_info = data.get('curHome', {})
homeid = home_info.get('objectId', homeid)   # -> "unknown" when curHome is absent
meshnet = homeid
```

Some accounts return `200 OK` on login but **omit `curHome` entirely**. The existing LiveGroup and Home-API fallbacks then query for home `"unknown"` and find nothing, so mesh metadata is never resolved.

The data is available, though — it just lives in the `Home` class. For an affected account, `GET /classes/Home` returns:

```
{"results":[{"objectId":"<homeid>","name":"<home>",
             "meshNet":<int>,"meshNet2":<int>,"netID":<int>}]}
```

## Fix

When `homeid` is unresolved after parsing the login response, query `/classes/Home` and adopt the first home's `objectId`, `name`, `meshNet`, `meshNet2`, and `netID`. No change for accounts that already return `curHome`.

The fix reuses the existing `API_URL["home"]`, `APPLICATION_ID`, `CLIENT_KEY`, and `httpx`, and is wrapped in try/except so it can never make setup worse than before.

## Testing

- Reproduced on a live account with no `curHome` (login `home=unknown meshNet=unknown` → setup aborted).
- With this change, the home (`meshNet`/`meshNet2`/`netID`) resolves via the Home class, validation passes, and the integration connects to the gateway and imports devices successfully.
- `python -m py_compile` passes; existing `curHome` path is unaffected.

## Notes

- If an account has multiple homes, this adopts the first returned. A follow-up could let the user pick, mirroring `curHome` selection in the app.
