### PR TITLE
Add brightness-only profile for rippleSHIELD SDD400RS/BTAM (type 2452)

### DIFF
--- a/custom_components/pixie_plus_local/pixie_value_profiles.py
+++ b/custom_components/pixie_plus_local/pixie_value_profiles.py
@@ -35,6 +35,7 @@ hardware_list = {
     "3002": "Smart passive infrared motion sensor - SMS862WF/WH/BTAM",    
     "2113": "Smart Timer Switch - STS600BTAM",
     "2552": "Smart Dimmer rippleSHIELD - SDD400RS/BTAM",
+    "2452": "Smart Dimmer rippleSHIELD - SDD400RS/BTAM",
     "1217": "Gate & Door Control - PC206GD/R/BTAM",
     "2704": "Strip Kit RGB - FLBP24V2RGB/BTAM",
 }
@@ -306,6 +307,24 @@ MODEL_CAPABILITIES: Dict[str, Dict[str, Any]] = {
         "color_temp_max_kelvin": 6500,
         "color_temp_cct_min": 0,
         "color_temp_cct_max": 255,
+        "supports_effects": False,
+        "supports_multi_channel": False,
+        "supports_usb_subentity": False,
+        "supports_cover": False,
+    },
+    # SDD400RS/BTAM reported as type/stype 2452 (same printed model as the 2552
+    # entry above). Profiled here as brightness-only. This hardware may itself be
+    # colour-temp capable like 2552 when paired with signal-controllable CCT
+    # downlights; it was characterised against an installation where colour
+    # temperature is fixed on the fixture (SAL S9041TC tri-colour switch) and the
+    # dimmer only controls brightness. If a 2452 is later confirmed to drive CCT
+    # over the rippleSHIELD signal, copy the colour-temp fields from 2552.
+    "2452": {
+        "is_light": True,
+        "is_switch": False,
+        "supports_onoff": True,
+        "supports_dimming": True,
+        "supports_color": False,
         "supports_effects": False,
         "supports_multi_channel": False,
         "supports_usb_subentity": False,


### PR DESCRIPTION
## Summary

I've got a couple of SDD400RS/BTAM dimmers that report as type/stype **2452**, which was absent from `pixie_value_profiles.py`. These devices were showing up with no `light`/`switch` entities.

## Fix

I've added `2452` to both `hardware_list` and `MODEL_CAPABILITIES` as a brightness-only dimmer (cloned from `2013` / SDD400SFI).

I note that the `2552` model appears to support CCT, but I'm not sure if the `2452` does. Mine are just hooked up to SAL S9041TC downlights with colour temperature set via a switch on the fixture. They only present a brightness control option in the PIXIE app. I'm not sure if the `2452` may also be CCT-capable when it's driving different downlights?

## Testing

Tested the updated `pixie_value_profiles.py` file on my Home Assistant instance with Pixie gateway:
- Device now appears as **Smart Dimmer rippleSHIELD - SDD400RS/BTAM (2452)**, a dimmable light.
- On/off and dimming verified via the gateway (state tracked correctly in both directions).
- Brightness reads as a direct 0–100 level (same encoding as the SFI sibling); no `0x80`-offset tunable-white decoding applies.